### PR TITLE
DA-3055: Fix issue bugzillarest not exported to CSV

### DIFF
--- a/affiliation/service.go
+++ b/affiliation/service.go
@@ -2643,6 +2643,9 @@ func (s *service) MakeDSInfo(actualArray []*models.DataSourceTypeFields, configu
 		_, sel := selected[configured]
 		item.FilterSelected = sel
 		if sel {
+			if configured == "bugzillarest" {
+				configured = "bugzilla"
+			}
 			_, present := actual[configured]
 			noData := !present
 			item.NoData = &noData


### PR DESCRIPTION
In case of DPDK project - bugzillarest ds (bugzilla) fields were not exported to CSV. However, topcontributors API response was showing the data correctly.

Below are few debug logs for reference - 
```
actual=map[bugzilla:{} git:{}]
configured=[bugzillarest git]
selected=map[bugzillarest:{} git:{}]
```
