### PR TITLE
add documentation endpoint

### DIFF
--- a/docs/doc.go
+++ b/docs/doc.go
@@ -1,0 +1,50 @@
+package docs
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+)
+
+// GetDocOK Success
+type GetDocOK struct {
+}
+
+// NewGetDocOK creates GetDocOK with default headers values
+func NewGetDocOK() *GetDocOK {
+	return &GetDocOK{}
+}
+
+// WriteResponse to the client
+func (o *GetDocOK) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+	html := `<!DOCTYPE html>
+	<html>
+	  <head>
+		<title>Insights Affiliations API ReDoc</title>
+		<!-- needed for adaptive design -->
+		<meta charset="utf-8"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link rel="shortcut icon" href="https://www.linuxfoundation.org/wp-content/uploads/2017/08/favicon.png">
+		<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+		<!--
+		ReDoc doesn't change outer page styles
+		-->
+		<style>
+		  body {
+			margin: 0;
+			padding: 0;
+		  }
+		</style>
+	  </head>
+	  <body>
+		<redoc spec-url='/swagger.json'></redoc>
+		<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+	  </body>
+	</html>`
+
+	rw.Header().Set("Content-Type", "text/html")
+	_, err := rw.Write([]byte(html))
+	if err != nil {
+		panic(err)
+	}
+}

--- a/docs/handlers.go
+++ b/docs/handlers.go
@@ -1,0 +1,15 @@
+package docs
+
+import (
+	"github.com/LF-Engineering/dev-analytics-affiliation/gen/restapi/operations"
+	d "github.com/LF-Engineering/dev-analytics-affiliation/gen/restapi/operations/docs"
+	"github.com/go-openapi/runtime/middleware"
+)
+
+// Configure configures the documentation service
+func Configure(api *operations.DevAnalyticsAffiliationAPI) {
+
+	api.DocsGetDocHandler = d.GetDocHandlerFunc(func(params d.GetDocParams) middleware.Responder {
+		return NewGetDocOK()
+	})
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/LF-Engineering/dev-analytics-affiliation/affiliation"
 	"github.com/LF-Engineering/dev-analytics-affiliation/apidb"
+	"github.com/LF-Engineering/dev-analytics-affiliation/docs"
 	"github.com/LF-Engineering/dev-analytics-affiliation/elastic"
 	"github.com/LF-Engineering/dev-analytics-affiliation/health"
 	"github.com/LF-Engineering/dev-analytics-affiliation/shared"
@@ -183,6 +184,7 @@ func main() {
 
 	health.Configure(api, healthService)
 	affiliation.Configure(api, affiliationService)
+	docs.Configure(api)
 
 	// When redeploying this needs to be cleared
 	affiliationService.ClearPrecacheRunning()

--- a/swagger/dev-analytics-affiliation.yaml
+++ b/swagger/dev-analytics-affiliation.yaml
@@ -6,6 +6,17 @@ info:
   description: Dev Analytics Affiliations API
 basePath: /v1
 paths:
+  /api-docs:
+    get:
+      summary: Get API documentation
+      operationId: getDoc
+      produces:
+        - text/html
+      responses:
+        200:
+          description: Success
+      tags:
+        - docs
   /health:
     get:
       summary: Health


### PR DESCRIPTION
documentation endpoint will be accessed via `{{baseURL}}/v1/api-docs`