### PR TITLE
DA-3331: org affiliation changes switch list org to use platform service - Part 1

### DIFF
--- a/affiliation/service.go
+++ b/affiliation/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/LF-Engineering/dev-analytics-affiliation/apidb"
 	"github.com/LF-Engineering/dev-analytics-affiliation/elastic"
 	"github.com/LF-Engineering/dev-analytics-affiliation/errs"
+	"github.com/LF-Engineering/dev-analytics-affiliation/platform"
 	"github.com/LF-Engineering/dev-analytics-affiliation/shared"
 	"github.com/LF-Engineering/dev-analytics-affiliation/shdb"
 
@@ -51,7 +52,7 @@ type Service interface {
 	GetMatchingBlacklist(context.Context, *affiliation.GetMatchingBlacklistParams) (*models.GetMatchingBlacklistOutput, error)
 	PostMatchingBlacklist(context.Context, *affiliation.PostMatchingBlacklistParams) (*models.MatchingBlacklistOutput, error)
 	DeleteMatchingBlacklist(context.Context, *affiliation.DeleteMatchingBlacklistParams) (*models.TextStatusOutput, error)
-	GetListOrganizations(context.Context, *affiliation.GetListOrganizationsParams) (*models.GetListOrganizationsOutput, error)
+	GetListOrganizations(context.Context, *affiliation.GetListOrganizationsParams) (*models.GetListOrganizationsServiceOutput, error)
 	GetListOrganizationsDomains(context.Context, *affiliation.GetListOrganizationsDomainsParams) (*models.GetListOrganizationsDomainsOutput, error)
 	GetFindOrganizationByID(context.Context, *affiliation.GetFindOrganizationByIDParams) (*models.OrganizationDataOutput, error)
 	GetFindOrganizationByName(context.Context, *affiliation.GetFindOrganizationByNameParams) (*models.OrganizationDataOutput, error)
@@ -136,15 +137,17 @@ type service struct {
 	shDB      shdb.Service
 	shDBGitdm shdb.Service
 	es        elastic.Service
+	platform  platform.Service
 }
 
 // New is a simple helper function to create a service instance
-func New(apiDB apidb.Service, shDBAPI, shDBGitdm shdb.Service, es elastic.Service) Service {
+func New(apiDB apidb.Service, shDBAPI, shDBGitdm shdb.Service, es elastic.Service, platformAPI platform.Service) Service {
 	return &service{
 		apiDB:     apiDB,
 		shDB:      shDBAPI,
 		shDBGitdm: shDBGitdm,
 		es:        es,
+		platform:  platformAPI,
 	}
 }
 
@@ -730,7 +733,7 @@ func (s *service) toNoDates(in *models.UniqueIdentityNestedDataOutput) (out *mod
 // q - optional query parameter: if you specify that parameter only organizations where name like '%q%' will be returned
 // rows - optional query parameter: rows per page, if 0 no paging is used and page parameter is ignored, default 10 (setting to zero still limits results to 65535)
 // page - optional query parameter: if set, it will return rows from a given page, default 1
-func (s *service) GetListOrganizations(ctx context.Context, params *affiliation.GetListOrganizationsParams) (getListOrganizations *models.GetListOrganizationsOutput, err error) {
+func (s *service) GetListOrganizations(ctx context.Context, params *affiliation.GetListOrganizationsParams) (getListOrganizations *models.GetListOrganizationsServiceOutput, err error) {
 	q := ""
 	if params.Q != nil {
 		q = *params.Q
@@ -749,7 +752,7 @@ func (s *service) GetListOrganizations(ctx context.Context, params *affiliation.
 			page = 1
 		}
 	}
-	getListOrganizations = &models.GetListOrganizationsOutput{}
+	getListOrganizations = &models.GetListOrganizationsServiceOutput{}
 	log.Info(fmt.Sprintf("GetListOrganizations: q:%s rows:%d page:%d", q, rows, page))
 	// Check token and permission
 	apiName, projects, username, err := s.checkTokenAndPermission(params)
@@ -759,7 +762,7 @@ func (s *service) GetListOrganizations(ctx context.Context, params *affiliation.
 		if nOrgs > shared.LogListMax {
 			list = fmt.Sprintf("%d", nOrgs)
 		} else {
-			list = fmt.Sprintf("%+v", s.ToLocalNestedOrganizations(getListOrganizations.Organizations))
+			//list = fmt.Sprintf("%+v", s.ToLocalNestedOrganizations(getListOrganizations.Organizations))
 		}
 		log.Info(
 			fmt.Sprintf(
@@ -779,11 +782,12 @@ func (s *service) GetListOrganizations(ctx context.Context, params *affiliation.
 		return
 	}
 	// Do the actual API call
-	getListOrganizations, err = s.shDB.GetListOrganizations(q, rows, page)
+	getListOrganizations, err = s.platform.GetListOrganizations(q, rows, page)
 	if err != nil {
 		err = errs.Wrap(err, apiName)
 		return
 	}
+
 	getListOrganizations.User = username
 	getListOrganizations.Scope = s.AryDA2SF(projects)
 	return
@@ -1037,10 +1041,47 @@ func (s *service) PostAddEnrollment(ctx context.Context, params *affiliation.Pos
 	if err != nil {
 		return
 	}
-	organization, err = s.shDB.GetOrganizationByName(params.OrgName, true, nil)
+	// setting missingFatal = false, as we can now look up org using org service
+	organization, err = s.shDB.GetOrganizationByName(params.OrgName, false, nil)
 	if err != nil {
 		err = errs.Wrap(err, apiName)
-		return
+		return nil, err
+	}
+
+	// If the user selected org does not exist in org table, we create the same in the organizations table.
+	// we get the domain from the lookup org service and then add the domain & org_name to the domain_organizations table.
+	if organization == nil {
+		sfdcOrg, err := s.platform.LookupOrganization(params.OrgName)
+		if err != nil {
+			err = errs.Wrap(err, apiName)
+			return nil, err
+		}
+		if sfdcOrg.Name != "" { // check to see whether Organization is available in org service or not
+			// Add org to affiliation db
+			organization, err = s.shDB.AddOrganization(
+				&models.OrganizationDataOutput{
+					Name: params.OrgName,
+				},
+				true,
+				nil,
+			)
+
+			if len(sfdcOrg.Domains) > 0 {
+				orgDomain := sfdcOrg.Domains[0].Name
+				// Add org and domain to affiliation db
+				_, err = s.shDB.PutOrgDomain(params.OrgName, orgDomain, false, true, true)
+				if err != nil {
+					err = errs.Wrap(err, apiName)
+					return nil, err
+				}
+			}
+		} else {
+			// Currently, we will return an error as organization is not present in SFDC nor in db
+			err = fmt.Errorf("Organization: '%s' not found in db as well org service", params.OrgName)
+			err = errs.Wrap(errs.New(err, errs.ErrBadRequest), "LookupOrganization")
+			return nil, err
+		}
+
 	}
 	enrollment.OrganizationID = organization.ID
 	uniqueIdentity := &models.UniqueIdentityDataOutput{}

--- a/helm/da-affiliation/templates/api.yaml
+++ b/helm/da-affiliation/templates/api.yaml
@@ -138,6 +138,56 @@ spec:
             secretKeyRef:
               name: {{ .Values.apiSecret }}
               key: CORS_ALLOWED_ORIGINS.secret
+        - name: ELASTIC_CACHE_URL
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: ELASTIC_CACHE_URL.secret
+        - name: ELASTIC_CACHE_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: ELASTIC_CACHE_USERNAME.secret
+        - name: ELASTIC_CACHE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: ELASTIC_CACHE_PASSWORD.secret
+        - name: STAGE
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: STAGE.secret
+        - name: AUTH0_PROD_GRANT_TYPE
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: AUTH0_PROD_GRANT_TYPE.secret
+        - name: AUTH0_PROD_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: AUTH0_PROD_CLIENT_ID.secret
+        - name: AUTH0_PROD_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: AUTH0_PROD_CLIENT_SECRET.secret
+        - name: AUTH0_PROD_AUDIENCE
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: AUTH0_PROD_AUDIENCE.secret
+        - name: AUTH0_TOKEN_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: AUTH0_TOKEN_ENDPOINT.secret
+        - name: PLATFORM_ORG_SERVICE_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.apiSecret }}
+              key: PLATFORM_ORG_SERVICE_ENDPOINT.secret
       restartPolicy: {{ .Values.apiRestartPolicy }}
       nodeSelector:
 {{- with .Values.nodeSelector -}}

--- a/helm/da-affiliation/templates/api.yaml
+++ b/helm/da-affiliation/templates/api.yaml
@@ -158,26 +158,21 @@ spec:
             secretKeyRef:
               name: {{ .Values.apiSecret }}
               key: STAGE.secret
-        - name: AUTH0_PROD_GRANT_TYPE
+        - name: AUTH0_GRANT_TYPE
           valueFrom:
             secretKeyRef:
               name: {{ .Values.apiSecret }}
-              key: AUTH0_PROD_GRANT_TYPE.secret
-        - name: AUTH0_PROD_CLIENT_ID
+              key: AUTH0_GRANT_TYPE.secret
+        - name: AUTH0_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
               name: {{ .Values.apiSecret }}
-              key: AUTH0_PROD_CLIENT_ID.secret
-        - name: AUTH0_PROD_CLIENT_SECRET
+              key: AUTH0_CLIENT_SECRET.secret
+        - name: AUTH0_AUDIENCE
           valueFrom:
             secretKeyRef:
               name: {{ .Values.apiSecret }}
-              key: AUTH0_PROD_CLIENT_SECRET.secret
-        - name: AUTH0_PROD_AUDIENCE
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Values.apiSecret }}
-              key: AUTH0_PROD_AUDIENCE.secret
+              key: AUTH0_AUDIENCE.secret
         - name: AUTH0_TOKEN_ENDPOINT
           valueFrom:
             secretKeyRef:

--- a/helm/da-affiliation/templates/secrets.yaml
+++ b/helm/da-affiliation/templates/secrets.yaml
@@ -15,10 +15,9 @@
 {{- $esCacheUser := .Files.Get (printf "secrets/ELASTIC_CACHE_USERNAME.%s.secret" .Values.deployEnv) -}}
 {{- $esCachePass := .Files.Get (printf "secrets/ELASTIC_CACHE_PASSWORD.%s.secret" .Values.deployEnv) -}}
 {{- $stage := .Files.Get (printf "secrets/STAGE.%s.secret" .Values.deployEnv) -}}
-{{- $auth0PrGt := .Files.Get (printf "secrets/AUTH0_PROD_GRANT_TYPE.%s.secret" .Values.deployEnv) -}}
-{{- $auth0PrCid := .Files.Get (printf "secrets/AUTH0_PROD_CLIENT_ID.%s.secret" .Values.deployEnv) -}}
-{{- $auth0PrCs := .Files.Get (printf "secrets/AUTH0_PROD_CLIENT_SECRET.%s.secret" .Values.deployEnv) -}}
-{{- $auth0PrAud := .Files.Get (printf "secrets/AUTH0_PROD_AUDIENCE.%s.secret" .Values.deployEnv) -}}
+{{- $auth0Gt := .Files.Get (printf "secrets/AUTH0_GRANT_TYPE.%s.secret" .Values.deployEnv) -}}
+{{- $auth0Cs := .Files.Get (printf "secrets/AUTH0_CLIENT_SECRET.%s.secret" .Values.deployEnv) -}}
+{{- $auth0Aud := .Files.Get (printf "secrets/AUTH0_AUDIENCE.%s.secret" .Values.deployEnv) -}}
 {{- $auth0TokenURL := .Files.Get (printf "secrets/AUTH0_TOKEN_ENDPOINT.%s.secret" .Values.deployEnv) -}}
 {{- $platformOrgURL := .Files.Get (printf "secrets/PLATFORM_ORG_SERVICE_ENDPOINT.%s.secret" .Values.deployEnv) -}}
 ---
@@ -39,10 +38,9 @@ data:
   ELASTIC_CACHE_USERNAME.secret: {{ $esCacheUser | b64enc }}
   ELASTIC_CACHE_PASSWORD.secret: {{ $esCachePass | b64enc }}
   STAGE.secret: {{ $stage | b64enc }}
-  AUTH0_PROD_GRANT_TYPE.secret: {{ $auth0PrGt | b64enc }}
-  AUTH0_PROD_CLIENT_ID.secret: {{ $auth0PrCid | b64enc }}
-  AUTH0_PROD_CLIENT_SECRET.secret: {{ $auth0PrCs | b64enc }}
-  AUTH0_PROD_AUDIENCE.secret: {{ $auth0PrAud | b64enc }}
+  AUTH0_GRANT_TYPE.secret: {{ $auth0Gt | b64enc }}
+  AUTH0_CLIENT_SECRET.secret: {{ $auth0Cs | b64enc }}
+  AUTH0_AUDIENCE.secret: {{ $auth0Aud | b64enc }}
   AUTH0_TOKEN_ENDPOINT.secret: {{ $auth0TokenURL | b64enc }}
   PLATFORM_ORG_SERVICE_ENDPOINT.secret: {{ $platformOrgURL | b64enc }}
 kind: Secret

--- a/helm/da-affiliation/templates/secrets.yaml
+++ b/helm/da-affiliation/templates/secrets.yaml
@@ -11,6 +11,16 @@
 {{- $auth0Ucl := .Files.Get (printf "secrets/AUTH0_USERNAME_CLAIM.%s.secret" .Values.deployEnv) -}}
 {{- $cors := .Files.Get (printf "secrets/CORS_ALLOWED_ORIGINS.%s.secret" .Values.deployEnv) -}}
 {{- $syncUrl := .Files.Get (printf "secrets/SYNC_URL.%s.secret" .Values.deployEnv) -}}
+{{- $esCacheURL := .Files.Get (printf "secrets/ELASTIC_CACHE_URL.%s.secret" .Values.deployEnv) -}}
+{{- $esCacheUser := .Files.Get (printf "secrets/ELASTIC_CACHE_USERNAME.%s.secret" .Values.deployEnv) -}}
+{{- $esCachePass := .Files.Get (printf "secrets/ELASTIC_CACHE_PASSWORD.%s.secret" .Values.deployEnv) -}}
+{{- $stage := .Files.Get (printf "secrets/STAGE.%s.secret" .Values.deployEnv) -}}
+{{- $auth0PrGt := .Files.Get (printf "secrets/AUTH0_PROD_GRANT_TYPE.%s.secret" .Values.deployEnv) -}}
+{{- $auth0PrCid := .Files.Get (printf "secrets/AUTH0_PROD_CLIENT_ID.%s.secret" .Values.deployEnv) -}}
+{{- $auth0PrCs := .Files.Get (printf "secrets/AUTH0_PROD_CLIENT_SECRET.%s.secret" .Values.deployEnv) -}}
+{{- $auth0PrAud := .Files.Get (printf "secrets/AUTH0_PROD_AUDIENCE.%s.secret" .Values.deployEnv) -}}
+{{- $auth0TokenURL := .Files.Get (printf "secrets/AUTH0_TOKEN_ENDPOINT.%s.secret" .Values.deployEnv) -}}
+{{- $platformOrgURL := .Files.Get (printf "secrets/PLATFORM_ORG_SERVICE_ENDPOINT.%s.secret" .Values.deployEnv) -}}
 ---
 apiVersion: v1
 data:
@@ -25,6 +35,16 @@ data:
   AUTH0_USERNAME_CLAIM.secret: {{ $auth0Ucl | b64enc }}
   CORS_ALLOWED_ORIGINS.secret: {{ $cors | b64enc }}
   SYNC_URL.secret: {{ $syncUrl | b64enc }}
+  ELASTIC_CACHE_URL.secret: {{ $esCacheURL | b64enc }}
+  ELASTIC_CACHE_USERNAME.secret: {{ $esCacheUser | b64enc }}
+  ELASTIC_CACHE_PASSWORD.secret: {{ $esCachePass | b64enc }}
+  STAGE.secret: {{ $stage | b64enc }}
+  AUTH0_PROD_GRANT_TYPE.secret: {{ $auth0PrGt | b64enc }}
+  AUTH0_PROD_CLIENT_ID.secret: {{ $auth0PrCid | b64enc }}
+  AUTH0_PROD_CLIENT_SECRET.secret: {{ $auth0PrCs | b64enc }}
+  AUTH0_PROD_AUDIENCE.secret: {{ $auth0PrAud | b64enc }}
+  AUTH0_TOKEN_ENDPOINT.secret: {{ $auth0TokenURL | b64enc }}
+  PLATFORM_ORG_SERVICE_ENDPOINT.secret: {{ $platformOrgURL | b64enc }}
 kind: Secret
 metadata:
   namespace: '{{ .Values.namespace }}'

--- a/main.go
+++ b/main.go
@@ -144,10 +144,10 @@ func initOrg() *orgservice.Org {
 		os.Getenv("ELASTIC_CACHE_USERNAME"),
 		os.Getenv("ELASTIC_CACHE_PASSWORD"),
 		os.Getenv("STAGE"),
-		os.Getenv("AUTH0_PROD_GRANT_TYPE"),
-		os.Getenv("AUTH0_PROD_CLIENT_ID"),
-		os.Getenv("AUTH0_PROD_CLIENT_SECRET"),
-		os.Getenv("AUTH0_PROD_AUDIENCE"),
+		os.Getenv("AUTH0_GRANT_TYPE"),
+		os.Getenv("AUTH0_CLIENT_ID"),
+		os.Getenv("AUTH0_CLIENT_SECRET"),
+		os.Getenv("AUTH0_AUDIENCE"),
 		os.Getenv("AUTH0_TOKEN_ENDPOINT"),
 	)
 

--- a/main.go
+++ b/main.go
@@ -13,17 +13,17 @@ import (
 
 	"github.com/LF-Engineering/dev-analytics-affiliation/affiliation"
 	"github.com/LF-Engineering/dev-analytics-affiliation/apidb"
+	"github.com/LF-Engineering/dev-analytics-affiliation/cmd"
 	"github.com/LF-Engineering/dev-analytics-affiliation/docs"
 	"github.com/LF-Engineering/dev-analytics-affiliation/elastic"
-	"github.com/LF-Engineering/dev-analytics-affiliation/health"
-	"github.com/LF-Engineering/dev-analytics-affiliation/shared"
-	"github.com/LF-Engineering/dev-analytics-affiliation/shdb"
-
-	"github.com/LF-Engineering/dev-analytics-affiliation/cmd"
 	"github.com/LF-Engineering/dev-analytics-affiliation/gen/restapi"
 	"github.com/LF-Engineering/dev-analytics-affiliation/gen/restapi/operations"
-
+	"github.com/LF-Engineering/dev-analytics-affiliation/health"
 	log "github.com/LF-Engineering/dev-analytics-affiliation/logging"
+	"github.com/LF-Engineering/dev-analytics-affiliation/platform"
+	"github.com/LF-Engineering/dev-analytics-affiliation/shared"
+	"github.com/LF-Engineering/dev-analytics-affiliation/shdb"
+	orgservice "github.com/LF-Engineering/dev-analytics-libraries/orgs"
 	"github.com/go-openapi/loads"
 
 	_ "github.com/joho/godotenv/autoload"
@@ -137,6 +137,27 @@ func initES() (*elasticsearch.Client, string) {
 	return client, esURL
 }
 
+func initOrg() *orgservice.Org {
+	orgClient, err := orgservice.NewClient(
+		os.Getenv("PLATFORM_ORG_SERVICE_ENDPOINT"),
+		os.Getenv("ELASTIC_CACHE_URL"),
+		os.Getenv("ELASTIC_CACHE_USERNAME"),
+		os.Getenv("ELASTIC_CACHE_PASSWORD"),
+		os.Getenv("STAGE"),
+		os.Getenv("AUTH0_PROD_GRANT_TYPE"),
+		os.Getenv("AUTH0_PROD_CLIENT_ID"),
+		os.Getenv("AUTH0_PROD_CLIENT_SECRET"),
+		os.Getenv("AUTH0_PROD_AUDIENCE"),
+		os.Getenv("AUTH0_TOKEN_ENDPOINT"),
+	)
+
+	if err != nil {
+		log.Panicf("unable to get org client info: %v", err)
+	}
+
+	log.Println("Initialized", "Org Service", host)
+	return orgClient
+}
 func setupEnv() {
 	shared.GSQLOut = os.Getenv("DA_AFF_API_SQL_OUT") != ""
 	shared.GSyncURL = os.Getenv("SYNC_URL")
@@ -180,7 +201,8 @@ func main() {
 	shDBServiceAPI := shdb.New(initSHDB(daOrigin), shDBRO, daOrigin)
 	shDBServiceGitdm := shdb.New(initSHDB(gitdmOrigin), shDBRO, gitdmOrigin)
 	esService := elastic.New(initES())
-	affiliationService := affiliation.New(apiDBService, shDBServiceAPI, shDBServiceGitdm, esService)
+	organizationServiceAPI := platform.New(initOrg())
+	affiliationService := affiliation.New(apiDBService, shDBServiceAPI, shDBServiceGitdm, esService, organizationServiceAPI)
 
 	health.Configure(api, healthService)
 	affiliation.Configure(api, affiliationService)

--- a/platform/organization.go
+++ b/platform/organization.go
@@ -1,0 +1,74 @@
+package platform
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/LF-Engineering/dev-analytics-affiliation/gen/models"
+	"github.com/LF-Engineering/dev-analytics-affiliation/shared"
+
+	log "github.com/LF-Engineering/dev-analytics-affiliation/logging"
+	"github.com/LF-Engineering/dev-analytics-libraries/orgs"
+)
+
+// Service - access platform org services
+type Service interface {
+	GetListOrganizations(string, int64, int64) (*models.GetListOrganizationsServiceOutput, error)
+	LookupOrganization(name string) (*models.OrganizationServiceDataOutput, error)
+}
+
+type service struct {
+	shared.ServiceStruct
+	client *orgs.Org
+}
+
+// New return ES connection
+func New(client *orgs.Org) Service {
+	return &service{
+		client: client,
+	}
+}
+
+// GetListOrganizations ...
+func (s *service) GetListOrganizations(q string, rows, page int64) (*models.GetListOrganizationsServiceOutput, error) {
+	getListOrganizations := &models.GetListOrganizationsServiceOutput{}
+	nRows := int64(0)
+	var orgs []*models.OrganizationServiceDataOutput
+	response, err := s.client.SearchOrganization(q, strconv.FormatInt(rows, 10), strconv.FormatInt(page, 10))
+	if err != nil {
+		return nil, err
+	}
+	for _, org := range response.Data {
+		orgs = append(orgs, &models.OrganizationServiceDataOutput{ID: (org.ID), Name: org.Name, Domains: []*models.DomainDataOutput{}})
+	}
+	log.Info(fmt.Sprintf("GetListOrganizations: q:%s rows:%d page:%d", q, rows, page))
+	getListOrganizations.Organizations = orgs
+	getListOrganizations.NRecords = nRows
+	getListOrganizations.Rows = int64(len(orgs))
+	if rows == 0 {
+		getListOrganizations.NPages = 1
+	} else {
+		pages := nRows / rows
+		if nRows%rows != 0 {
+			pages++
+		}
+		getListOrganizations.NPages = pages
+	}
+	getListOrganizations.Page = page
+	if q != "" {
+		getListOrganizations.Search = "q=" + q
+	}
+	return getListOrganizations, nil
+}
+
+// LookupOrganization ...
+func (s *service) LookupOrganization(name string) (*models.OrganizationServiceDataOutput, error) {
+	org, err := s.client.LookupOrganization(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.OrganizationServiceDataOutput{ID: org.ID, Name: org.Name,
+			Domains: []*models.DomainDataOutput{{Name: org.Link, OrganizationName: org.Name}}},
+		nil
+}

--- a/swagger/dev-analytics-affiliation.yaml
+++ b/swagger/dev-analytics-affiliation.yaml
@@ -281,7 +281,7 @@ paths:
               type: string
               description: Request ID
           schema:
-            $ref: "#/definitions/get-list-organizations-output"
+            $ref: "#/definitions/get-list-organizations-service-output"
         "400":
           $ref: "#/responses/bad-request"
         "401":
@@ -2499,6 +2499,51 @@ definitions:
         type: array
         items:
           $ref: "#/definitions/domain-data-output"
+  organization-service-data-output:
+    title: Organization data with nested organization domains
+    description: Organization data with nested organization domains
+    type: object
+    properties:
+      id:
+        type: string
+        example: "00Ta3420000Te"
+      name:
+        type: string
+        example: CNCF
+      domains:
+        type: array
+        items:
+          $ref: "#/definitions/domain-data-output"
+  get-list-organizations-service-output:
+    title: List organizations data output
+    description: List organizations data
+    type: object
+    properties:
+      user:
+        type: string
+        example: testusername
+      scope:
+        type: string
+        example: academy-software-foundation/opencue
+      n_pages:
+        type: integer
+        example: 10
+      page:
+        type: integer
+        example: 1
+      search:
+        type: string
+        example: 'q=root'
+      n_records:
+        type: integer
+        example: 55
+      rows:
+        type: integer
+        example: 9
+      organizations:
+        type: array
+        items:
+          $ref: "#/definitions/organization-service-data-output"
   get-list-organizations-output:
     title: List organizations data output
     description: List organizations data


### PR DESCRIPTION
Jira Ticket: https://jira.linuxfoundation.org/browse/DA-3331

Below 2 APIs are updated as per Case 1 mentioned here - https://jira.linuxfoundation.org/browse/DA-3331?focusedCommentId=410087&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-410087

`list_organizations`
`add_enrollment`

For e.g. 

http://127.0.1.1:8080/v1/affiliation/project1/list_organizations?q=linux%20foundation&page=1&rows=10 now returns data using org service 
```

{
    "organizations": [
        {
            "domains": [],
            "id": "0016s000006UKKqAAO",
            "name": "The Linux Foundation"
        }
    ],
    "page": 1,
    "rows": 1,
    "scope": "project1",
    "search": "q=The Linux Foundation ",
    "user": "ajinkyan"
}

```

Also verified and tested add enrollment API locally using test env vars - http://127.0.1.1:8080/v1/affiliation/project1/add_enrollment/... 

A new env variable is introduced `PLATFORM_ORG_SERVICE_ENDPOINT` which points to `https://api-gw.dev.platform.linuxfoundation.org/organization-service/v1` for dev endpoint.

In case the org does not exist both in affiliations db and org service (SFDC), I am returning an error for now as shown below -

`{"error":"LookupOrganization: Organization: 'The Linux Foundadadadadadation Test3' not found in db as well org service","level":"error","msg":"PostAddEnrollmentHandlerFunc(error): Request IP: 10.0.2.2:62351, Request Agent: PostmanRuntime/7.26.8, method: POST, path: /v1/affiliation/project1/add_enrollment/fa880b65f6af233ff3be9cf0ed8d2cd307ac1ad5/The Linux Foundadadadadadation Test3","time":"2021-01-25T17:47:03+05:30"}`

Related PR: https://github.com/LF-Engineering/dev-analytics-libraries/pull/21
