### PR TITLE
(Prod) DA-3490: address org service defect with single result as offset was set to 1 by default

### DIFF
--- a/platform/organization.go
+++ b/platform/organization.go
@@ -34,7 +34,7 @@ func (s *service) GetListOrganizations(q string, rows, page int64) (*models.GetL
 	getListOrganizations := &models.GetListOrganizationsServiceOutput{}
 	nRows := int64(0)
 	var orgs []*models.OrganizationServiceDataOutput
-	response, err := s.client.SearchOrganization(q, strconv.FormatInt(rows, 10), strconv.FormatInt(page, 10))
+	response, err := s.client.SearchOrganization(q, strconv.FormatInt(rows, 10), strconv.FormatInt(page-1, 10))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Addressed issue where single result was returned as Org service offset starts from 0.

**Testing done:**
verified below 2 APIs

http://localhost:8080/v1/affiliation/cncf%2Fk8s/list_organizations?q=Facebook&page=1&rows=10
```
{
    "organizations": [
        {
            "domains": [],
            "id": "0014100000TdzwSAAR",
            "name": "Facebook, Inc."
        }
    ],
    "page": 1,
    "rows": 1,
    "scope": "k8s",
    "search": "q=Facebook",
    "user": "internal-api-user"
}
```
http://localhost:8080/v1/affiliation/cncf%2Fk8s/list_organizations?q=Individual - No Account&page=1&rows=10

```
{
    "organizations": [
        {
            "domains": [],
            "id": "0014100001NrJWnAAN",
            "name": "Individual - No Account"
        }
    ],
    "page": 1,
    "rows": 1,
    "scope": "k8s",
    "search": "q=Individual - No Account",
    "user": "internal-api-user"
}
```