### PR TITLE
[prod] DA-3521: Add organizaiton mapping

### DIFF
--- a/map_org_names.yaml
+++ b/map_org_names.yaml
@@ -3571,4 +3571,4 @@ mappings:
   - ['^[[:space:]]*apigee[[:space:]]\\(?apic\\)?[[:space:]]*$','Apigee Corporation']
   - ['^[[:space:]]*ipreo[[:space:]]*$', 'IHS Markit']
   - ['^[[:space:]]*cantor[[:space:]]fitzgerald[[:space:]]*$', 'Cantor Fitzgerald, L.P.']
-  - ['^[[:space:]]*(t-mobile[[:space:]]polska|t-mobile[[:space:]]pcs[[:space:]]holdings[[:space:]]llc|deutsche[[:space:]]telekom|t-systems)[[:space:]]*$', 'Deutsche Telekom AG']
+  - ['^[[:space:]]*(t-mobile[[:space:]]+polska|t-mobile[[:space:]]+pcs([[:space:]]+holdings)?|deutsche[[:space:]]+telekom|t-systems)[[:space:]]*(,?)[[:space:]]*(llc|corp)?(\.?)[[:space:]]*$', 'Deutsche Telekom AG']

--- a/map_org_names.yaml
+++ b/map_org_names.yaml
@@ -3571,3 +3571,4 @@ mappings:
   - ['^[[:space:]]*apigee[[:space:]]\\(?apic\\)?[[:space:]]*$','Apigee Corporation']
   - ['^[[:space:]]*ipreo[[:space:]]*$', 'IHS Markit']
   - ['^[[:space:]]*cantor[[:space:]]fitzgerald[[:space:]]*$', 'Cantor Fitzgerald, L.P.']
+  - ['^[[:space:]]*(T-Mobile[[:space:]]Polska|T-Mobile[[:space:]]PCS[[:space:]]Holdings[[:space:]]LLC|Deutsche[[:space:]]Telekom|T-Systems)[[:space:]]*$', 'Deutsche Telekom AG']

--- a/map_org_names.yaml
+++ b/map_org_names.yaml
@@ -3571,4 +3571,4 @@ mappings:
   - ['^[[:space:]]*apigee[[:space:]]\\(?apic\\)?[[:space:]]*$','Apigee Corporation']
   - ['^[[:space:]]*ipreo[[:space:]]*$', 'IHS Markit']
   - ['^[[:space:]]*cantor[[:space:]]fitzgerald[[:space:]]*$', 'Cantor Fitzgerald, L.P.']
-  - ['^[[:space:]]*(T-Mobile[[:space:]]Polska|T-Mobile[[:space:]]PCS[[:space:]]Holdings[[:space:]]LLC|Deutsche[[:space:]]Telekom|T-Systems)[[:space:]]*$', 'Deutsche Telekom AG']
+  - ['^[[:space:]]*(t-mobile[[:space:]]polska|t-mobile[[:space:]]pcs[[:space:]]holdings[[:space:]]llc|deutsche[[:space:]]telekom|t-systems)[[:space:]]*$', 'Deutsche Telekom AG']


### PR DESCRIPTION
Map the following org names to the Deutsche Telekom AG
• Deutsche Telekom
• T-Systems
• T-Mobile PCS Holdings LLC
• T-Mobile Polska