### PR TITLE
Add locked_by support in all APIs

### DIFF
--- a/sql/add_locked_by.sql
+++ b/sql/add_locked_by.sql
@@ -1,0 +1,5 @@
+-- Adds `locked_by` column to DB tables
+alter table enrollments add locked_by varchar(128);
+alter table identities add locked_by varchar(128);
+alter table profiles add locked_by varchar(128);
+alter table uidentities add locked_by varchar(128);


### PR DESCRIPTION
We need `locked_by` on the "profiles" and "identities" tables too.

Why? If we don't have `locked_by` there, deleting "uidentity" or "profile" table record triggers (on the DB level) dropping of all given profile/uidentity's identities and enrollments sub records.

So 4 tables need "locked_by": identities, enrollments, profiles & uidentities.

This adds support for "freezing" any record that has non-empty `locked_by` column.

Next, I think, importing enrollment/identity should set `locked_by` on given identity's/enrollment's profile and uidentity parent record - so this is no longer possible to delete/edit a profile/uidentity that has any identity/enrollments changed from the individual dashboard.

cc @1010sachin @fayazg 

Signed-off-by: Łukasz Gryglicki <lgryglicki@cncf.io>